### PR TITLE
Add documentation link to README and pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It also enables the generation of content such as tables, plots, and other visua
 
 The package is hosted on GitHub: [https://github.com/basnijholt/markdown-code-runner](https://github.com/basnijholt/markdown-code-runner)
 
+:book: **Documentation**: [https://markdown-code-runner.nijho.lt](https://markdown-code-runner.nijho.lt)
+
 <!-- SECTION:features:START -->
 ## :star: Features
 - :rocket: Automatically execute code blocks, including hidden code blocks, within a Markdown file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ content-type = "text/markdown"
 
 [project.urls]
 Homepage = "https://github.com/basnijholt/markdown-code-runner"
+Documentation = "https://markdown-code-runner.nijho.lt"
 
 [project.optional-dependencies]
 test = ["pytest", "pre-commit", "coverage", "pytest-cov"]


### PR DESCRIPTION
Adds the documentation site URL (https://markdown-code-runner.nijho.lt) to:
- README.md
- pyproject.toml `[project.urls]`