### PR TITLE
Add shields to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Markdown Code Runner
 
+[![PyPI](https://img.shields.io/pypi/v/markdown-code-runner)](https://pypi.org/project/markdown-code-runner/)
+[![Python](https://img.shields.io/pypi/pyversions/markdown-code-runner)](https://pypi.org/project/markdown-code-runner/)
+[![License](https://img.shields.io/github/license/basnijholt/markdown-code-runner)](LICENSE)
+[![Downloads](https://img.shields.io/pypi/dm/markdown-code-runner)](https://pypi.org/project/markdown-code-runner/)
+[![CI](https://img.shields.io/github/actions/workflow/status/basnijholt/markdown-code-runner/pytest.yml?label=tests)](https://github.com/basnijholt/markdown-code-runner/actions/workflows/pytest.yml)
+[![Docs](https://img.shields.io/badge/docs-markdown--code--runner.nijho.lt-blue)](https://markdown-code-runner.nijho.lt)
+
 <img src="https://raw.githubusercontent.com/basnijholt/markdown-code-runner/main/docs/assets/logo.svg" alt="Markdown Code Runner Logo" align="right" style="width: 200px;" />
 
 <!-- SECTION:intro:START -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,17 @@ authors = [{ name = "Bas Nijholt", email = "bas@nijho.lt" }]
 dependencies = []
 requires-python = ">=3.9"
 dynamic = ["version"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
 
 [project.readme]
 file = "README.md"


### PR DESCRIPTION
## Summary
Add badges below the header for quick project info:

- PyPI version
- Python versions supported
- License
- Monthly downloads
- CI status
- Documentation link

## Test plan
- [x] Verify shields render correctly on GitHub