### PR TITLE
Strip markdown-code-runner modifier from code fences in docs

### DIFF
--- a/docs/docs_gen.py
+++ b/docs/docs_gen.py
@@ -98,7 +98,17 @@ def _transform_readme_links(content: str) -> str:
         content = content.replace(f"]({old_link})", f"]({new_link})")
 
     # Remove ToC link pattern [[ToC](#...)]
-    return re.sub(r"\[\[ToC\]\([^)]+\)\]", "", content)
+    content = re.sub(r"\[\[ToC\]\([^)]+\)\]", "", content)
+
+    # Strip 'markdown-code-runner' modifier from code fence language identifiers
+    # e.g., "```python markdown-code-runner" -> "```python"
+    # This is needed because the docs site renderer doesn't understand this syntax
+    return re.sub(
+        r"^(```\w+)\s+markdown-code-runner(?:\s+\S+=\S+)?$",
+        r"\1",
+        content,
+        flags=re.MULTILINE,
+    )
 
 
 def _find_markdown_files_with_code_blocks(docs_dir: Path) -> list[Path]:


### PR DESCRIPTION
## Summary
- The docs site renderer (Zensical/pymdownx) doesn't understand code fence language identifiers like `python markdown-code-runner`
- This caused fenced code blocks to be parsed incorrectly, breaking the Examples page rendering
- Added a regex transformation to strip the `markdown-code-runner` modifier when pulling content from README

## Test plan
- [x] Verified docs build successfully with `uv run zensical build`
- [x] Verified code blocks now render with proper syntax highlighting
- [ ] CI should pass and Examples page should render correctly