### PR TITLE
Support indented code blocks (fixes #11)

### DIFF
--- a/markdown_code_runner.py
+++ b/markdown_code_runner.py
@@ -284,6 +284,11 @@ class ProcessingState:
                     return line
         return None
 
+    @staticmethod
+    def _get_indent(line: str) -> str:
+        """Extract leading whitespace from a line."""
+        return line[: len(line) - len(line.lstrip())]
+
     def _process_output_start(self, line: str) -> None:
         self.section = "output"
         if not self.skip_code_block:
@@ -291,16 +296,11 @@ class ProcessingState:
                 self.output,
                 list,
             ), f"Output must be a list, not {type(self.output)}, line: {line}"
-            # Extract indent from OUTPUT:START line
-            output_indent = line[: len(line) - len(line.lstrip())]
-
-            def _add_indent(s: str) -> str:
-                stripped = s.rstrip()
-                return output_indent + stripped if stripped else ""
-
-            trimmed_output = [_add_indent(ol) for ol in self.output]
-            indented_warning = output_indent + MARKERS["warning"]
-            self.new_lines.extend([line, indented_warning, *trimmed_output])
+            indent = self._get_indent(line)
+            trimmed_output = [
+                indent + ol.rstrip() if ol.strip() else "" for ol in self.output
+            ]
+            self.new_lines.extend([line, indent + MARKERS["warning"], *trimmed_output])
         else:
             self.original_output.append(line)
 

--- a/markdown_code_runner.py
+++ b/markdown_code_runner.py
@@ -265,23 +265,21 @@ class ProcessingState:
         verbose: bool = False,  # noqa: FBT001, FBT002, ARG002
     ) -> str | None:
         for marker_name in MARKERS:
-            if marker_name.endswith(":start"):
-                match = is_marker(line, marker_name)
-                if match:
-                    # reset output in case previous output wasn't displayed
-                    self.output = None
-                    self.backtick_options = _extract_backtick_options(line)
-                    self.section, _ = marker_name.rsplit(":", 1)  # type: ignore[assignment]
-                    self.indent = match.group("spaces")
+            if marker_name.endswith(":start") and is_marker(line, marker_name):
+                # reset output in case previous output wasn't displayed
+                self.output = None
+                self.backtick_options = _extract_backtick_options(line)
+                self.section, _ = marker_name.rsplit(":", 1)  # type: ignore[assignment]
+                self.indent = self._get_indent(line)
 
-                    # Standardize backticks if needed
-                    if (
-                        marker_name == "code:backticks:start"
-                        and self.backtick_standardize
-                        and "markdown-code-runner" in line
-                    ):
-                        return re.sub(r"\smarkdown-code-runner.*", "", line)
-                    return line
+                # Standardize backticks if needed
+                if (
+                    marker_name == "code:backticks:start"
+                    and self.backtick_standardize
+                    and "markdown-code-runner" in line
+                ):
+                    return re.sub(r"\smarkdown-code-runner.*", "", line)
+                return line
         return None
 
     @staticmethod

--- a/tests/test_main_app.py
+++ b/tests/test_main_app.py
@@ -881,3 +881,79 @@ def test_trailing_whitespace_trimming() -> None:
     assert output_section_hidden[3] == "Final line"
     assert output_section_hidden[4] == ""  # Line with only spaces becomes empty
     assert output_section_hidden[5] == ""  # Trailing empty line preserved
+
+
+def test_indented_code_blocks() -> None:
+    """Test that indented code blocks (e.g., in list items) work correctly."""
+    # Test case 1: Indented backtick code block (4 spaces, like in a list)
+    input_lines = [
+        "1. List item:",
+        "",
+        "    ```python markdown-code-runner",
+        "    print('hello')",
+        "    ```",
+        "    <!-- OUTPUT:START -->",
+        "    old output",
+        "    <!-- OUTPUT:END -->",
+    ]
+    expected_output = [
+        "1. List item:",
+        "",
+        "    ```python markdown-code-runner",
+        "    print('hello')",
+        "    ```",
+        "    <!-- OUTPUT:START -->",
+        "    " + MARKERS["warning"],
+        "    hello",
+        "",
+        "    <!-- OUTPUT:END -->",
+    ]
+    assert_process(input_lines, expected_output, backtick_standardize=False)
+
+    # Test case 2: Indented code with internal indentation (Python function)
+    input_lines = [
+        "1. Example:",
+        "",
+        "    ```python markdown-code-runner",
+        "    def foo():",
+        "        return 42",
+        "    print(foo())",
+        "    ```",
+        "    <!-- OUTPUT:START -->",
+        "    <!-- OUTPUT:END -->",
+    ]
+    expected_output = [
+        "1. Example:",
+        "",
+        "    ```python markdown-code-runner",
+        "    def foo():",
+        "        return 42",
+        "    print(foo())",
+        "    ```",
+        "    <!-- OUTPUT:START -->",
+        "    " + MARKERS["warning"],
+        "    42",
+        "",
+        "    <!-- OUTPUT:END -->",
+    ]
+    assert_process(input_lines, expected_output, backtick_standardize=False)
+
+    # Test case 3: Indented bash code block
+    input_lines = [
+        "    ```bash markdown-code-runner",
+        '    echo "indented bash"',
+        "    ```",
+        "    <!-- OUTPUT:START -->",
+        "    <!-- OUTPUT:END -->",
+    ]
+    expected_output = [
+        "    ```bash markdown-code-runner",
+        '    echo "indented bash"',
+        "    ```",
+        "    <!-- OUTPUT:START -->",
+        "    " + MARKERS["warning"],
+        "    indented bash",
+        "",
+        "    <!-- OUTPUT:END -->",
+    ]
+    assert_process(input_lines, expected_output, backtick_standardize=False)


### PR DESCRIPTION
## Summary
- Code blocks inside list items or other indented contexts now work correctly
- The indentation prefix is stripped from code before execution
- Output lines are re-indented to match the OUTPUT:START marker's indentation

## Test plan
- [x] Added test cases for indented Python, Python with internal indentation, and Bash
- [x] All 38 tests pass with 100% coverage
- [x] README processing verified to work correctly

Fixes #11