### PR TITLE
Switch to ruff format, 120 char line length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,19 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: mixed-line-ending
-  - repo: "https://github.com/ambv/black"
-    rev: 25.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.11
     hooks:
-      - id: black-jupyter
-        language_version: python3
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.11.2"
-    hooks:
+      - id: ruff-format
       - id: ruff
         args: ["--fix"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.15.0"
+    rev: "v1.19.1"
     hooks:
       - id: mypy
         additional_dependencies: ["types-PyYAML", "types-requests", "types-setuptools"]

--- a/markdown_code_runner.py
+++ b/markdown_code_runner.py
@@ -295,9 +295,7 @@ class ProcessingState:
                 list,
             ), f"Output must be a list, not {type(self.output)}, line: {line}"
             indent = self._get_indent(line)
-            trimmed_output = [
-                indent + ol.rstrip() if ol.strip() else "" for ol in self.output
-            ]
+            trimmed_output = [indent + ol.rstrip() if ol.strip() else "" for ol in self.output]
             self.new_lines.extend([line, indent + MARKERS["warning"], *trimmed_output])
         else:
             self.original_output.append(line)
@@ -340,9 +338,7 @@ class ProcessingState:
             self.indent = ""
         else:
             # remove_md_comment already strips whitespace; for backticks, strip indent
-            code_line = (
-                remove_md_comment(line) if remove_comment else self._strip_indent(line)
-            )
+            code_line = remove_md_comment(line) if remove_comment else self._strip_indent(line)
             self.code.append(code_line)
 
     def _process_comment_code(self, line: str, *, verbose: bool) -> None:
@@ -454,9 +450,7 @@ def update_markdown_file(  # noqa: PLR0913
 
     if verbose:
         print(f"Writing output to: {output_filepath}")
-    output_filepath = (
-        input_filepath if output_filepath is None else Path(output_filepath)
-    )
+    output_filepath = input_filepath if output_filepath is None else Path(output_filepath)
     with output_filepath.open("w") as f:
         f.write(updated_content)
     if verbose:
@@ -519,9 +513,7 @@ def main() -> None:
     output_filepath = Path(args.output) if args.output is not None else input_filepath
 
     # Determine backtick standardization
-    backtick_standardize = (
-        False if args.no_backtick_standardize else args.output is not None
-    )
+    backtick_standardize = False if args.no_backtick_standardize else args.output is not None
 
     update_markdown_file(
         input_filepath,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,30 +57,30 @@ exclude_lines = [
     "if __name__ == .__main__.:",
 ]
 
-[tool.black]
-line_length = 88
-
 [tool.ruff]
-line-length = 150
+line-length = 120
 target-version = "py39"
+
+[tool.ruff.lint]
 select = ["ALL"]
 ignore = [
     "T20",     # flake8-print
-    "ANN101",  # Missing type annotation for {name} in method
     "S101",    # Use of assert detected
-    "PD901",   # df is a bad variable name. Be kinder to your future self.
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed in {name}
     "D402",    # First line should not be the function's signature
     "PLW0603", # Using the global statement to update `X` is discouraged
     "D401",    # First line of docstring should be in imperative mood
+    "COM812",  # Conflicts with ruff formatter
+    "D203",    # Conflicts with D211
+    "D213",    # Conflicts with D212
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["SLF001"]
 "ci/*" = ["INP001"]
 "tests/test_examples.py" = ["E501"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 18
 
 [tool.mypy]

--- a/tests/test_main_app.py
+++ b/tests/test_main_app.py
@@ -176,9 +176,7 @@ def test_remove_md_comment() -> None:
     """Test the remove_md_comment function."""
     input_str = "<!-- This is a comment -->"
     output_str = remove_md_comment(input_str)
-    assert (
-        output_str == "This is a comment"
-    ), f"Expected 'This is a comment', got '{output_str}'"
+    assert output_str == "This is a comment", f"Expected 'This is a comment', got '{output_str}'"
 
     input_str = "This is not a comment"
     with pytest.raises(ValueError, match="Invalid Markdown comment format"):


### PR DESCRIPTION
## Summary
- Replace black with ruff-format in pre-commit
- Set line-length to 120 (was 88 for black, 150 for ruff)
- Migrate to `ruff.lint.*` config sections (fixes deprecation warnings)
- Remove deprecated rule ignores (ANN101, PD901)
- Add formatter-conflicting rules to ignore (COM812, D203, D213)

## Test plan
- [x] All pre-commit hooks pass
- [x] All 38 tests pass with 100% coverage