### PR TITLE
Add built-in include_section() function for content extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It also enables the generation of content such as tables, plots, and other visua
 - Easily integrates with GitHub Actions
 - No external dependencies and works with Python 3.7+
 - Execute *all* languages by using the file code blocks and executing it with bash (see [Rust example](#idea-7-run-a-rust-program))
+- Built-in `section()` function to extract and reuse content from other Markdown files
 <!-- SECTION:features:END -->
 
 <!-- SECTION:problem-statement:START -->
@@ -50,6 +51,8 @@ This ensures that the displayed output is always in sync with the code, and cont
 - [Examples](#examples)
   - [Example 1: Simple code block](#example-1-simple-code-block)
   - [Example 2: Multiple code blocks](#example-2-multiple-code-blocks)
+- [Built-in Functions](#built-in-functions)
+  - [`section(file, name, strip_heading=False)`](#sectionfile-name-strip_headingfalse)
 - [Usage Ideas](#usage-ideas)
   - [Idea 1: Continuous Integration with GitHub Actions](#idea-1-continuous-integration-with-github-actions)
   - [Idea 2: Show command-line output](#idea-2-show-command-line-output)
@@ -243,6 +246,58 @@ Hello again!
 <!-- OUTPUT:END -->
 ```
 <!-- SECTION:examples:END -->
+
+<!-- SECTION:builtin-functions:START -->
+## Built-in Functions
+
+Code blocks executed by `markdown-code-runner` have access to built-in helper functions.
+
+### `section(file, name, strip_heading=False)`
+
+Extract content from a markdown file that is marked with SECTION markers. This is useful for reusing content across multiple files without duplication.
+
+**Parameters:**
+- `file`: Path to the markdown file (relative to the current file, or absolute)
+- `name`: The section name to extract
+- `strip_heading`: If `True`, removes the first heading from the extracted content
+
+**Example:**
+
+In your source file (`README.md`):
+<!-- CODE:SKIP -->
+```markdown
+<!-- SECTION:intro:START -->
+## Introduction
+
+This is reusable content.
+<!-- SECTION:intro:END -->
+```
+
+In another file that wants to include this section:
+<!-- CODE:SKIP -->
+```markdown
+<!-- CODE:START -->
+<!-- print(section("README.md", "intro")) -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+<!-- OUTPUT:END -->
+```
+
+After running `markdown-code-runner`, the output section will contain:
+```markdown
+## Introduction
+
+This is reusable content.
+```
+
+Use `strip_heading=True` to remove the heading:
+<!-- CODE:SKIP -->
+```markdown
+<!-- CODE:START -->
+<!-- print(section("README.md", "intro", strip_heading=True)) -->
+<!-- CODE:END -->
+```
+<!-- SECTION:builtin-functions:END -->
 
 <!-- SECTION:usage-ideas:START -->
 ## Usage Ideas

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It also enables the generation of content such as tables, plots, and other visua
 - Easily integrates with GitHub Actions
 - No external dependencies and works with Python 3.7+
 - Execute *all* languages by using the file code blocks and executing it with bash (see [Rust example](#idea-7-run-a-rust-program))
-- Built-in `section()` function to extract and reuse content from other Markdown files
+- Built-in `include_section()` function to extract and reuse content from other Markdown files
 <!-- SECTION:features:END -->
 
 <!-- SECTION:problem-statement:START -->
@@ -52,7 +52,7 @@ This ensures that the displayed output is always in sync with the code, and cont
   - [Example 1: Simple code block](#example-1-simple-code-block)
   - [Example 2: Multiple code blocks](#example-2-multiple-code-blocks)
 - [Built-in Functions](#built-in-functions)
-  - [`section(file, name, strip_heading=False)`](#sectionfile-name-strip_headingfalse)
+  - [`include_section(file, name, strip_heading=False)`](#include_sectionfile-name-strip_headingfalse)
 - [Usage Ideas](#usage-ideas)
   - [Idea 1: Continuous Integration with GitHub Actions](#idea-1-continuous-integration-with-github-actions)
   - [Idea 2: Show command-line output](#idea-2-show-command-line-output)
@@ -252,7 +252,7 @@ Hello again!
 
 Code blocks executed by `markdown-code-runner` have access to built-in helper functions.
 
-### `section(file, name, strip_heading=False)`
+### `include_section(file, name, strip_heading=False)`
 
 Extract content from a markdown file that is marked with SECTION markers. This is useful for reusing content across multiple files without duplication.
 
@@ -277,7 +277,7 @@ In another file that wants to include this section:
 <!-- CODE:SKIP -->
 ```markdown
 <!-- CODE:START -->
-<!-- print(section("README.md", "intro")) -->
+<!-- print(include_section("README.md", "intro")) -->
 <!-- CODE:END -->
 <!-- OUTPUT:START -->
 <!-- OUTPUT:END -->
@@ -294,7 +294,7 @@ Use `strip_heading=True` to remove the heading:
 <!-- CODE:SKIP -->
 ```markdown
 <!-- CODE:START -->
-<!-- print(section("README.md", "intro", strip_heading=True)) -->
+<!-- print(include_section("README.md", "intro", strip_heading=True)) -->
 <!-- CODE:END -->
 ```
 <!-- SECTION:builtin-functions:END -->

--- a/markdown_code_runner.py
+++ b/markdown_code_runner.py
@@ -64,24 +64,24 @@ def md_comment(text: str) -> str:
     return f"<!-- {text} -->"
 
 
-def _create_section_func(base_path: Path | None) -> Callable[..., str]:
-    """Create a section() function that resolves paths relative to base_path.
+def _create_include_section_func(base_path: Path | None) -> Callable[..., str]:
+    """Create an include_section() function that resolves paths relative to base_path.
 
     Parameters
     ----------
     base_path
         The path to the markdown file being processed. Relative paths in
-        section() calls will be resolved relative to this file's directory.
+        include_section() calls will be resolved relative to this file's directory.
 
     Returns
     -------
     Callable
-        A section(file, name, strip_heading=False) function.
+        An include_section(file, name, strip_heading=False) function.
 
     """
 
-    def section(file: str, name: str, *, strip_heading: bool = False) -> str:
-        """Extract a marked section from a Markdown file.
+    def include_section(file: str, name: str, *, strip_heading: bool = False) -> str:
+        """Include a marked section from a Markdown file.
 
         Sections are marked with HTML comments:
             <!-- SECTION:name:START -->
@@ -134,7 +134,7 @@ def _create_section_func(base_path: Path | None) -> Callable[..., str]:
 
         return result
 
-    return section
+    return include_section
 
 
 MARKERS = {
@@ -466,7 +466,7 @@ def process_markdown(
         return content
 
     # Initialize context with built-in functions
-    initial_context = {"section": _create_section_func(base_path)}
+    initial_context = {"include_section": _create_include_section_func(base_path)}
     state = ProcessingState(backtick_standardize=backtick_standardize, context=initial_context)
 
     for i, line in enumerate(content):

--- a/markdown_code_runner.py
+++ b/markdown_code_runner.py
@@ -49,7 +49,7 @@ import subprocess
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 try:
     __version__ = version("markdown-code-runner")
@@ -62,6 +62,79 @@ DEBUG: bool = os.environ.get("DEBUG", "0") == "1"
 def md_comment(text: str) -> str:
     """Format a string as a Markdown comment."""
     return f"<!-- {text} -->"
+
+
+def _create_section_func(base_path: Path | None) -> Callable[..., str]:
+    """Create a section() function that resolves paths relative to base_path.
+
+    Parameters
+    ----------
+    base_path
+        The path to the markdown file being processed. Relative paths in
+        section() calls will be resolved relative to this file's directory.
+
+    Returns
+    -------
+    Callable
+        A section(file, name, strip_heading=False) function.
+
+    """
+
+    def section(file: str, name: str, *, strip_heading: bool = False) -> str:
+        """Extract a marked section from a Markdown file.
+
+        Sections are marked with HTML comments:
+            <!-- SECTION:name:START -->
+            content here
+            <!-- SECTION:name:END -->
+
+        Parameters
+        ----------
+        file
+            Path to the markdown file (relative to current file, or absolute).
+        name
+            The section name to extract.
+        strip_heading
+            If True, remove the first heading (# through ######) from the section.
+
+        Returns
+        -------
+        str
+            The content between the section markers.
+
+        Raises
+        ------
+        ValueError
+            If the section markers are not found.
+
+        """
+        path = Path(file)
+        if not path.is_absolute() and base_path is not None:
+            path = base_path.parent / path
+
+        content = path.read_text()
+
+        start_marker = f"<!-- SECTION:{name}:START -->"
+        end_marker = f"<!-- SECTION:{name}:END -->"
+
+        start_idx = content.find(start_marker)
+        if start_idx == -1:
+            msg = f"Section '{name}' not found in {file}"
+            raise ValueError(msg)
+
+        end_idx = content.find(end_marker, start_idx)
+        if end_idx == -1:
+            msg = f"End marker for section '{name}' not found in {file}"
+            raise ValueError(msg)
+
+        result = content[start_idx + len(start_marker) : end_idx].strip()
+
+        if strip_heading:
+            result = re.sub(r"^#{1,6}\s+[^\n]+\n+", "", result, count=1)
+
+        return result
+
+    return section
 
 
 MARKERS = {
@@ -363,6 +436,7 @@ def process_markdown(
     verbose: bool = False,
     backtick_standardize: bool = True,
     execute: bool = True,
+    base_path: Path | None = None,
 ) -> list[str]:
     """Executes code blocks in a list of Markdown-formatted strings and returns the modified list.
 
@@ -377,6 +451,9 @@ def process_markdown(
     execute
         If True, execute code blocks and update output sections.
         If False, return content unchanged (useful with post-processing standardization).
+    base_path
+        Path to the markdown file being processed. Used by built-in functions
+        like section() to resolve relative paths.
 
     Returns
     -------
@@ -388,7 +465,9 @@ def process_markdown(
     if not execute:
         return content
 
-    state = ProcessingState(backtick_standardize=backtick_standardize)
+    # Initialize context with built-in functions
+    initial_context = {"section": _create_section_func(base_path)}
+    state = ProcessingState(backtick_standardize=backtick_standardize, context=initial_context)
 
     for i, line in enumerate(content):
         if verbose:
@@ -439,6 +518,7 @@ def update_markdown_file(  # noqa: PLR0913
         verbose=verbose,
         backtick_standardize=backtick_standardize,
         execute=execute,
+        base_path=input_filepath,
     )
     updated_content = "\n".join(new_lines).rstrip() + "\n"
 

--- a/tests/test_main_app.py
+++ b/tests/test_main_app.py
@@ -958,8 +958,8 @@ def test_indented_code_blocks() -> None:
     assert_process(input_lines, expected_output, backtick_standardize=False)
 
 
-def test_section_function(tmp_path: Path) -> None:
-    """Test the built-in section() function."""
+def test_include_section_function(tmp_path: Path) -> None:
+    """Test the built-in include_section() function."""
     # Create a source file with sections
     source_file = tmp_path / "source.md"
     source_file.write_text(
@@ -990,7 +990,7 @@ Footer text.
         """# Test Doc
 
 <!-- CODE:START -->
-<!-- print(section("source.md", "intro")) -->
+<!-- print(include_section("source.md", "intro")) -->
 <!-- CODE:END -->
 <!-- OUTPUT:START -->
 old content
@@ -1006,8 +1006,8 @@ old content
     assert "old content" not in result
 
 
-def test_section_function_strip_heading(tmp_path: Path) -> None:
-    """Test section() with strip_heading=True."""
+def test_include_section_function_strip_heading(tmp_path: Path) -> None:
+    """Test include_section() with strip_heading=True."""
     source_file = tmp_path / "source.md"
     source_file.write_text(
         """<!-- SECTION:intro:START -->
@@ -1023,7 +1023,7 @@ This is the intro section.
         """# Test Doc
 
 <!-- CODE:START -->
-<!-- print(section("source.md", "intro", strip_heading=True)) -->
+<!-- print(include_section("source.md", "intro", strip_heading=True)) -->
 <!-- CODE:END -->
 <!-- OUTPUT:START -->
 old
@@ -1038,15 +1038,15 @@ old
     assert "This is the intro section." in result
 
 
-def test_section_function_not_found(tmp_path: Path) -> None:
-    """Test section() raises ValueError when section not found."""
+def test_include_section_function_not_found(tmp_path: Path) -> None:
+    """Test include_section() raises ValueError when section not found."""
     source_file = tmp_path / "source.md"
     source_file.write_text("# No sections here\n")
 
     md_file = tmp_path / "test.md"
     md_file.write_text(
         """<!-- CODE:START -->
-<!-- print(section("source.md", "nonexistent")) -->
+<!-- print(include_section("source.md", "nonexistent")) -->
 <!-- CODE:END -->
 <!-- OUTPUT:START -->
 <!-- OUTPUT:END -->
@@ -1057,8 +1057,8 @@ def test_section_function_not_found(tmp_path: Path) -> None:
         update_markdown_file(md_file)
 
 
-def test_section_function_missing_end_marker(tmp_path: Path) -> None:
-    """Test section() raises ValueError when end marker is missing."""
+def test_include_section_function_missing_end_marker(tmp_path: Path) -> None:
+    """Test include_section() raises ValueError when end marker is missing."""
     source_file = tmp_path / "source.md"
     source_file.write_text(
         """<!-- SECTION:broken:START -->
@@ -1069,7 +1069,7 @@ Content without end marker
     md_file = tmp_path / "test.md"
     md_file.write_text(
         """<!-- CODE:START -->
-<!-- print(section("source.md", "broken")) -->
+<!-- print(include_section("source.md", "broken")) -->
 <!-- CODE:END -->
 <!-- OUTPUT:START -->
 <!-- OUTPUT:END -->

--- a/tests/test_main_app.py
+++ b/tests/test_main_app.py
@@ -18,6 +18,7 @@ from markdown_code_runner import (
     md_comment,
     process_markdown,
     remove_md_comment,
+    update_markdown_file,
 )
 
 TEST_FOLDER = Path(__file__).parent
@@ -955,3 +956,125 @@ def test_indented_code_blocks() -> None:
         "    <!-- OUTPUT:END -->",
     ]
     assert_process(input_lines, expected_output, backtick_standardize=False)
+
+
+def test_section_function(tmp_path: Path) -> None:
+    """Test the built-in section() function."""
+    # Create a source file with sections
+    source_file = tmp_path / "source.md"
+    source_file.write_text(
+        """# Main Title
+
+Some intro text.
+
+<!-- SECTION:intro:START -->
+## Introduction
+
+This is the intro section.
+<!-- SECTION:intro:END -->
+
+<!-- SECTION:features:START -->
+## Features
+
+- Feature 1
+- Feature 2
+<!-- SECTION:features:END -->
+
+Footer text.
+"""
+    )
+
+    # Create a markdown file that uses section()
+    md_file = tmp_path / "test.md"
+    md_file.write_text(
+        """# Test Doc
+
+<!-- CODE:START -->
+<!-- print(section("source.md", "intro")) -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+old content
+<!-- OUTPUT:END -->
+"""
+    )
+
+    update_markdown_file(md_file)
+
+    result = md_file.read_text()
+    assert "## Introduction" in result
+    assert "This is the intro section." in result
+    assert "old content" not in result
+
+
+def test_section_function_strip_heading(tmp_path: Path) -> None:
+    """Test section() with strip_heading=True."""
+    source_file = tmp_path / "source.md"
+    source_file.write_text(
+        """<!-- SECTION:intro:START -->
+## Introduction
+
+This is the intro section.
+<!-- SECTION:intro:END -->
+"""
+    )
+
+    md_file = tmp_path / "test.md"
+    md_file.write_text(
+        """# Test Doc
+
+<!-- CODE:START -->
+<!-- print(section("source.md", "intro", strip_heading=True)) -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+old
+<!-- OUTPUT:END -->
+"""
+    )
+
+    update_markdown_file(md_file)
+
+    result = md_file.read_text()
+    assert "## Introduction" not in result
+    assert "This is the intro section." in result
+
+
+def test_section_function_not_found(tmp_path: Path) -> None:
+    """Test section() raises ValueError when section not found."""
+    source_file = tmp_path / "source.md"
+    source_file.write_text("# No sections here\n")
+
+    md_file = tmp_path / "test.md"
+    md_file.write_text(
+        """<!-- CODE:START -->
+<!-- print(section("source.md", "nonexistent")) -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+<!-- OUTPUT:END -->
+"""
+    )
+
+    with pytest.raises(ValueError, match="Section 'nonexistent' not found"):
+        update_markdown_file(md_file)
+
+
+def test_section_function_missing_end_marker(tmp_path: Path) -> None:
+    """Test section() raises ValueError when end marker is missing."""
+    source_file = tmp_path / "source.md"
+    source_file.write_text(
+        """<!-- SECTION:broken:START -->
+Content without end marker
+"""
+    )
+
+    md_file = tmp_path / "test.md"
+    md_file.write_text(
+        """<!-- CODE:START -->
+<!-- print(section("source.md", "broken")) -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+<!-- OUTPUT:END -->
+"""
+    )
+
+    with pytest.raises(ValueError, match="End marker for section 'broken' not found"):
+        update_markdown_file(md_file)


### PR DESCRIPTION
## Summary

- Adds a built-in `include_section(file, name, strip_heading=False)` function available in CODE blocks
- Extracts content between `<!-- SECTION:name:START -->` and `<!-- SECTION:name:END -->` markers
- Paths are resolved relative to the markdown file being processed
- Enables DRY documentation patterns where content can be defined once and reused across files

## Motivation

Several projects using markdown-code-runner (like dotbins, loc, agent-cli) implement their own `readme_section()` function to extract and reuse content. This adds first-party support so projects can delete their custom implementations.

## Usage

```markdown
<!-- CODE:START -->
<!-- print(include_section("../README.md", "intro")) -->
<!-- CODE:END -->
<!-- OUTPUT:START -->
<!-- OUTPUT:END -->
```

With heading stripping:
```markdown
<!-- CODE:START -->
<!-- print(include_section("README.md", "features", strip_heading=True)) -->
<!-- CODE:END -->
```

## Test plan

- [x] Added tests for basic section extraction
- [x] Added tests for `strip_heading=True`
- [x] Added tests for error cases (section not found, missing end marker)
- [x] All 30 tests pass
- [x] All pre-commit hooks pass (ruff, mypy)