### PR TITLE
Add support for processing multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,12 +420,12 @@ Which is rendered as:
 ```bash
 usage: markdown-code-runner [-h] [-o OUTPUT] [-d] [-v]
                             [--no-backtick-standardize] [-s] [-n]
-                            input
+                            input [input ...]
 
 Automatically update Markdown files with code block output.
 
 positional arguments:
-  input                 Path to the input Markdown file.
+  input                 Path(s) to the input Markdown file(s).
 
 options:
   -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -138,10 +138,16 @@ To get started with `markdown-code-runner`, follow these steps:
     <!-- OUTPUT:END -->
     ```
 
-2.  Run `markdown-code-runner` on your Markdown file:
+2.  Run `markdown-code-runner` on your Markdown file(s):
 
     ```bash
     markdown-code-runner /path/to/your/markdown_file.md
+    ```
+
+    You can also process multiple files at once:
+
+    ```bash
+    markdown-code-runner docs/*.md README.md
     ```
 
 3.  The output of the code block will be automatically executed and inserted between the output markers.

--- a/markdown_code_runner.py
+++ b/markdown_code_runner.py
@@ -545,7 +545,8 @@ def main() -> None:
     parser.add_argument(
         "input",
         type=str,
-        help="Path to the input Markdown file.",
+        nargs="+",
+        help="Path(s) to the input Markdown file(s).",
     )
     parser.add_argument(
         "-o",
@@ -589,20 +590,25 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    input_filepath = Path(args.input)
-    output_filepath = Path(args.output) if args.output is not None else input_filepath
+    input_files = [Path(f) for f in args.input]
 
-    # Determine backtick standardization
-    backtick_standardize = False if args.no_backtick_standardize else args.output is not None
+    if args.output is not None and len(input_files) > 1:
+        parser.error("--output cannot be used with multiple input files")
 
-    update_markdown_file(
-        input_filepath,
-        output_filepath,
-        verbose=args.verbose,
-        backtick_standardize=backtick_standardize,
-        execute=not args.no_execute,
-        standardize=args.standardize,
-    )
+    for input_filepath in input_files:
+        output_filepath = Path(args.output) if args.output is not None else input_filepath
+
+        # Determine backtick standardization
+        backtick_standardize = False if args.no_backtick_standardize else args.output is not None
+
+        update_markdown_file(
+            input_filepath,
+            output_filepath,
+            verbose=args.verbose,
+            backtick_standardize=backtick_standardize,
+            execute=not args.no_execute,
+            standardize=args.standardize,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_main_app.py
+++ b/tests/test_main_app.py
@@ -201,7 +201,7 @@ def test_main_no_arguments(tmp_path: Path) -> None:
     with patch(
         "argparse.ArgumentParser.parse_args",
         return_value=argparse.Namespace(
-            input=test_filepath,
+            input=[str(test_filepath)],
             output=None,
             verbose=False,
             no_backtick_standardize=True,
@@ -224,7 +224,7 @@ def test_main_filepath_argument(tmp_path: Path) -> None:
     with patch(
         "argparse.ArgumentParser.parse_args",
         return_value=argparse.Namespace(
-            input=test_filepath,
+            input=[str(test_filepath)],
             output=str(output_filepath),
             verbose=False,
             no_backtick_standardize=True,
@@ -247,7 +247,7 @@ def test_main_debug_mode(capfd: pytest.CaptureFixture, tmp_path: Path) -> None:
     with patch(
         "argparse.ArgumentParser.parse_args",
         return_value=argparse.Namespace(
-            input=test_filepath,
+            input=[str(test_filepath)],
             output=str(output_filepath),
             verbose=True,
             no_backtick_standardize=True,
@@ -1078,3 +1078,71 @@ Content without end marker
 
     with pytest.raises(ValueError, match="End marker for section 'broken' not found"):
         update_markdown_file(md_file)
+
+
+def test_main_multiple_files(tmp_path: Path) -> None:
+    """Test the main function with multiple input files."""
+    # Create two test files
+    file1 = tmp_path / "file1.md"
+    file1.write_text(
+        """<!-- CODE:START -->
+<!-- print("file1") -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+old content
+<!-- OUTPUT:END -->
+"""
+    )
+
+    file2 = tmp_path / "file2.md"
+    file2.write_text(
+        """<!-- CODE:START -->
+<!-- print("file2") -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+old content
+<!-- OUTPUT:END -->
+"""
+    )
+
+    with patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(
+            input=[str(file1), str(file2)],
+            output=None,
+            verbose=False,
+            no_backtick_standardize=True,
+            standardize=False,
+            no_execute=False,
+        ),
+    ):
+        main()
+
+    # Check that both files were processed
+    assert "file1" in file1.read_text()
+    assert "file2" in file2.read_text()
+
+
+def test_main_multiple_files_with_output_error(tmp_path: Path) -> None:
+    """Test that --output with multiple files raises an error."""
+    file1 = tmp_path / "file1.md"
+    file1.write_text("# File 1\n")
+    file2 = tmp_path / "file2.md"
+    file2.write_text("# File 2\n")
+    output = tmp_path / "output.md"
+
+    with (
+        patch(
+            "argparse.ArgumentParser.parse_args",
+            return_value=argparse.Namespace(
+                input=[str(file1), str(file2)],
+                output=str(output),
+                verbose=False,
+                no_backtick_standardize=True,
+                standardize=False,
+                no_execute=False,
+            ),
+        ),
+        pytest.raises(SystemExit),
+    ):
+        main()


### PR DESCRIPTION
## Summary

- CLI now accepts multiple input files: `markdown-code-runner *.md`
- Files are processed in-place when multiple inputs are provided
- The `--output` flag is incompatible with multiple files (raises error with helpful message)

## Usage

```bash
# Process multiple files at once
markdown-code-runner docs/*.md README.md

# Still works with single file
markdown-code-runner README.md

# Output flag only works with single file
markdown-code-runner README.md -o output.md
```

## Test plan

- [x] Added test for processing multiple files
- [x] Added test that --output with multiple files raises error
- [x] Updated existing tests to use list format for input
- [x] All 32 tests pass
- [x] All pre-commit hooks pass (ruff, mypy)